### PR TITLE
Multiple status updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Floobits
+.floo*

--- a/src/ploneintranet/notifications/tests/test_adapters.py
+++ b/src/ploneintranet/notifications/tests/test_adapters.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
+import time
 from datetime import datetime
+import transaction
 from plone import api
 from plone.app.testing.interfaces import TEST_USER_PASSWORD
 from plone.app.testing.interfaces import TEST_USER_ROLES
 from ploneintranet.notifications.testing import \
     PLONEINTRANET_NOTIFICATIONS_INTEGRATION_TESTING
+from ploneintranet.notifications.testing import \
+    PLONEINTRANET_NOTIFICATIONS_FUNCTIONAL_TESTING
 from plonesocial.microblog.statusupdate import StatusUpdate
+from plonesocial.microblog.testing import tearDownContainer
 import unittest
 
 
-class TestAdapters(unittest.TestCase):
-
-    layer = PLONEINTRANET_NOTIFICATIONS_INTEGRATION_TESTING
+class SetUpMixin(object):
 
     def setUp(self):
         self.app = self.layer['app']
@@ -38,6 +41,11 @@ class TestAdapters(unittest.TestCase):
                 'email': 'kelly@sjogren.se',
                 'fullname': 'Kelly Sjögren',
             })  # randomly generated
+
+
+class TestAdapters(SetUpMixin, unittest.TestCase):
+
+    layer = PLONEINTRANET_NOTIFICATIONS_INTEGRATION_TESTING
 
     def test_page(self):
         ''' Let's try to create a page and inspect the created adapter
@@ -66,6 +74,19 @@ class TestAdapters(unittest.TestCase):
             message.obj['message_last_modification_date'],
             datetime
         )
+
+
+class TestStatusAdapters(SetUpMixin, unittest.TestCase):
+
+    layer = PLONEINTRANET_NOTIFICATIONS_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestStatusAdapters, self).setUp()
+        transaction.commit()
+
+    def tearDown(self):
+        container = api.portal.get_tool('plonesocial_microblog')
+        tearDownContainer(container)
 
     def test_status_update(self):
         ''' Let's try to create a status_update and inspect the created adapter
@@ -96,3 +117,72 @@ class TestAdapters(unittest.TestCase):
             message.obj['message_last_modification_date'],
             datetime
         )
+
+    def test_multiple_status_updates(self):
+        ''' Let's try to create multiple status updates.
+
+        This lets us enter into the threaded handling of status commits
+        (where the commit is done at most once per second,
+        in a separate thread)
+        '''
+        with api.env.adopt_user('test_user_adapters_'):
+            pm = api.portal.get_tool('plonesocial_microblog')
+            # HIC SUNT LEONES
+            #
+            # The problem here is threaded queue flushing from the
+            # status update container.
+            # The objective is to run notifications adapters in a thread.
+            # This however is complicated by the fact
+            # that we have multiple transactions at once,
+            # one here in the test (primary)
+            # and another from the scheduled autoflush in another thread.
+            # Once the latter one commits,
+            # this transaction is hopelessly out of date
+            # (keep in mind ZODB is MVCC)
+            # and we must get a fresh new transaction.
+            # To get this we can either commit or abort,
+            # but if we commit, we have a conflict error
+            # (this happens only in tests, really, I think due to DemoStorage)
+            # so we must abort.
+            # But if we abort, some status updates are going to be lost,
+            # specifically the first and the last (more on this later).
+            # So what we do is:
+            #
+            #  * Create a first expendable status
+            #  * Create ten statuses we will test
+            #  * Create a last expendable status
+            #  * Do some magic to ensure the damned threaded autoflush runs
+            #  * Abort the transaction
+            #  * PROFIT!
+            #
+            # Why the first and last statuses are lost?
+            #
+            # Because the queued autoflush "kicks in"
+            # from the second status onward.
+            # This means the first status gets added
+            # within the transaction that we abort
+            # (and not within the transaction that gets committed,
+            # which is the one in the thread), so it gets lost.
+            # The same holds for the last one, which triggers the queue
+            # flushing but gets similarly stuck in the doomed transaction.
+            su = StatusUpdate(u'Test à FIRST')
+            pm.add(su)
+            for i in xrange(0, 10):
+                su = StatusUpdate(u'Test à {}'.format(unicode(i+1)))
+                pm.add(su)
+            time.sleep(2)
+            su = StatusUpdate(u'Test à LAST')
+            pm.add(su)
+            time.sleep(0.5)
+            if getattr(pm, '_v_timer', None) is not None:
+                pm._v_timer.join()
+            transaction.abort()
+        pin = api.portal.get_tool('ploneintranet_notifications')
+        messages = pin.get_user_queue(api.user.get('test_user_adapters_'))
+        self.assertGreaterEqual(len(messages), 10)
+
+        for i, message in enumerate(messages[-11:-1]):
+            self.assertEqual(message.predicate, 'STATUS_UPDATE')
+            self.assertEqual(message.obj['title'], u'Test à {}'.format(
+                unicode(i+1)
+            ))


### PR DESCRIPTION
Added a test that fails when the thread that enqueues and adds multiple status updates doesn't set the site correctly.